### PR TITLE
decode html special chars in uris taken from parsed document

### DIFF
--- a/src/lib/Base/Www/Html/Document.php
+++ b/src/lib/Base/Www/Html/Document.php
@@ -77,6 +77,7 @@ class Document
         $files = $matches[1];
 
         if (!is_null($uri)) {
+            $uri = htmlspecialchars_decode($uri);
             $uri = new Uri($uri);
             $cleanFiles = array();
             foreach ($files as $file) {


### PR DESCRIPTION
Not tested yet, but should fix problems when urls have encoded html special characters.

Example:

<link rel="alternate" href="http://www.brigitte.de?jfPD_device=portable&amp;jfPD_appType=web&amp;jfPD_size=2" media="only screen and (max-width: 640px)" />
