### PR TITLE
make Document->getExternalDependencies regex non-greedy to avoid edge-cas...

### DIFF
--- a/src/lib/Base/Www/Html/Document.php
+++ b/src/lib/Base/Www/Html/Document.php
@@ -69,7 +69,7 @@ class Document
     {
         if (!is_array($fileExtensions)) return false;
         $extensions = implode('|', $fileExtensions);
-        $pattern = '/[^\'](?:<link|<script).*(?:href|src)=["\']([\S]+\.(?:'.$extensions.')+[?\S]*)[\'"][^\']/i';
+        $pattern = '/[^\'](?:<link|<script).*(?:href|src)=["\']([\S]+\.(?:'.$extensions.')+[?\S]*)[\'"][^\']/iU';
 
         $matches = array();
         preg_match_all($pattern, $this->content, $matches);


### PR DESCRIPTION
The original greedy regex had problems recoginizing dynamically inserted scripts:

Example Source Code:

```
...
<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
<script>window.jQuery || document.write('<script src="/vendor/jquery/jquery.min.js"><\/script>')</script>
...
```

Example output before patch (greedy regex):

```
array(2) {

array(2) {
  [0]=>
  string(59) "//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"
  [1]=>
  string(40) "/vendor/jquery/jquery.min.js"><\/script>"
}
```

Example output after patch (non-greedy regex):

```
array(2) {
  [0]=>
  string(59) "//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"
  [1]=>
  string(28) "/vendor/jquery/jquery.min.js"
}
```
